### PR TITLE
Allow block padding of size 4

### DIFF
--- a/format.go
+++ b/format.go
@@ -410,8 +410,8 @@ func (h *blockHeader) UnmarshalBinary(data []byte) error {
 	// Since headerLen is a multiple of 4 we don't need to check
 	// alignment.
 	k := r.Len()
-	if k > 3 {
-		return errors.New("xz: unexpected padding size")
+	if k > 4 { // The spec says 0-3 but actual files (e.g. FreeBSD base.txz) contain padding of length 4
+		return fmt.Errorf("xz: unexpected padding size %d", k)
 	}
 	if !allZeros(data[n-k : n]) {
 		return errPadding


### PR DESCRIPTION
Seems like some real files e.g. [base.txz](http://ftp.freebsd.org/pub/FreeBSD/releases/amd64/11.0-RELEASE/base.txz) (presumably, created with official XZ Utils — that's the xz implementation that comes with FreeBSD) don't agree with the spec…