### PR TITLE
Add a go.mod file to support Go modules.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/ulikunitz/xz


### PR DESCRIPTION
In order to work well with [Go modules][1] a package should have a `go.mod`
file and semantic version tags on release versions. This repo already has
release tags, but hitherto no `go.mod` file.

This commit contains no functional changes, but after merging it will need a
new patch or minor version bump to touch a commit containing it.

[1]: https://github.com/golang/go/wiki/Modules