### PR TITLE
Change lit type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ cmd/xb/xb
 
 # default compression test file
 enwik8*
+
+# profiling output
+/*.pdf
+/*.svg
+

--- a/lzma/bintree.go
+++ b/lzma/bintree.go
@@ -78,7 +78,7 @@ func (t *binTree) SetDict(d *encoderDict) { t.dict = d }
 
 // WriteByte writes a single byte into the binary tree.
 func (t *binTree) WriteByte(c byte) error {
-	t.x = (t.x << 8) | uint32(c)
+	t.x = t.x<<8 | uint32(c)
 	t.hoff++
 	if t.hoff < 0 {
 		return nil
@@ -434,7 +434,7 @@ func (t *binTree) match(m match, distIter func() (int, bool), p matchParams,
 				continue
 			}
 		}
-		if n < m.n || (n == m.n && int64(dist) >= m.distance) {
+		if n < m.n || n == m.n && int64(dist) >= m.distance {
 			continue
 		}
 		m = match{int64(dist), n}
@@ -517,7 +517,7 @@ func (t *binTree) NextOp(rep [4]uint32) operation {
 	m, _, _ = t.match(m, iterPred, p)
 end:
 	if m.n == 0 {
-		return lit{t.data[0]}
+		return lit(t.data[0])
 	}
 	return m
 }

--- a/lzma/decoder.go
+++ b/lzma/decoder.go
@@ -70,7 +70,7 @@ func (d *decoder) decodeLiteral() (op operation, err error) {
 	if err != nil {
 		return nil, err
 	}
-	return lit{s}, nil
+	return lit(s), nil
 }
 
 // errEOS indicates that an EOS marker has been found.
@@ -182,7 +182,7 @@ func (d *decoder) apply(op operation) error {
 	case match:
 		err = d.Dict.writeMatch(x.distance, x.n)
 	case lit:
-		err = d.Dict.WriteByte(x.b)
+		err = d.Dict.WriteByte(byte(x))
 	default:
 		panic("op is neither a match nor a literal")
 	}

--- a/lzma/encoder.go
+++ b/lzma/encoder.go
@@ -108,7 +108,7 @@ func (e *encoder) writeLiteral(l lit) error {
 	}
 	litState := e.state.litState(e.dict.ByteAt(1), e.dict.Pos())
 	match := e.dict.ByteAt(int(e.state.rep[0]) + 1)
-	err = e.state.litCodec.Encode(e.re, l.b, state, match, litState)
+	err = e.state.litCodec.Encode(e.re, byte(l), state, match, litState)
 	if err != nil {
 		return err
 	}

--- a/lzma/hashtable.go
+++ b/lzma/hashtable.go
@@ -94,7 +94,7 @@ func newHashTable(capacity int, wordLen int) (t *hashTable, err error) {
 	t = &hashTable{
 		t:       make([]int64, n),
 		data:    make([]uint32, capacity),
-		mask:    (uint64(1) << uint(exp)) - 1,
+		mask:    uint64(1)<<uint(exp) - 1,
 		hoff:    -int64(wordLen),
 		wordLen: wordLen,
 		wr:      newRoller(wordLen),
@@ -303,7 +303,7 @@ func (t *hashTable) NextOp(rep [4]uint32) operation {
 	}
 
 	if m.n == 0 {
-		return lit{data[0]}
+		return lit(data[0])
 	}
 	return m
 }

--- a/lzma/literalcodec.go
+++ b/lzma/literalcodec.go
@@ -46,15 +46,15 @@ func (c *literalCodec) Encode(e *rangeEncoder, s byte,
 	if state >= 7 {
 		m := uint32(match)
 		for {
-			matchBit := (m >> 7) & 1
+			matchBit := m >> 7 & 1
 			m <<= 1
-			bit := (r >> 7) & 1
+			bit := r >> 7 & 1
 			r <<= 1
-			i := ((1 + matchBit) << 8) | symbol
+			i := (1+matchBit)<<8 | symbol
 			if err = probs[i].Encode(e, bit); err != nil {
 				return
 			}
-			symbol = (symbol << 1) | bit
+			symbol = symbol<<1 | bit
 			if matchBit != bit {
 				break
 			}
@@ -64,12 +64,12 @@ func (c *literalCodec) Encode(e *rangeEncoder, s byte,
 		}
 	}
 	for symbol < 0x100 {
-		bit := (r >> 7) & 1
+		bit := r >> 7 & 1
 		r <<= 1
 		if err = probs[symbol].Encode(e, bit); err != nil {
 			return
 		}
-		symbol = (symbol << 1) | bit
+		symbol = symbol<<1 | bit
 	}
 	return nil
 }
@@ -85,14 +85,14 @@ func (c *literalCodec) Decode(d *rangeDecoder,
 	if state >= 7 {
 		m := uint32(match)
 		for {
-			matchBit := (m >> 7) & 1
+			matchBit := m >> 7 & 1
 			m <<= 1
-			i := ((1 + matchBit) << 8) | symbol
+			i := (1+matchBit)<<8 | symbol
 			bit, err := d.DecodeBit(&probs[i])
 			if err != nil {
 				return 0, err
 			}
-			symbol = (symbol << 1) | bit
+			symbol = symbol<<1 | bit
 			if matchBit != bit {
 				break
 			}
@@ -106,7 +106,7 @@ func (c *literalCodec) Decode(d *rangeDecoder,
 		if err != nil {
 			return 0, err
 		}
-		symbol = (symbol << 1) | bit
+		symbol = symbol<<1 | bit
 	}
 	s = byte(symbol - 0x100)
 	return s, nil

--- a/lzma/operation.go
+++ b/lzma/operation.go
@@ -69,10 +69,10 @@ func (l lit) Len() int {
 // String returns a string representation for the literal.
 func (l lit) String() string {
 	var c byte
-	if unicode.IsPrint(rune(l.b)) {
-		c = l.b
+	if unicode.IsPrint(rune(l)) {
+		c = byte(l)
 	} else {
 		c = '.'
 	}
-	return fmt.Sprintf("L{%c/%02x}", c, l.b)
+	return fmt.Sprintf("L{%c/%02x}", c, byte(l))
 }

--- a/lzma/operation.go
+++ b/lzma/operation.go
@@ -59,9 +59,7 @@ func (m match) String() string {
 }
 
 // lit represents a single byte literal.
-type lit struct {
-	b byte
-}
+type lit byte
 
 // Len returns 1 for the single byte literal.
 func (l lit) Len() int {

--- a/lzma/rangecodec.go
+++ b/lzma/rangecodec.go
@@ -55,7 +55,7 @@ func (e *rangeEncoder) writeByte(c byte) error {
 // DirectEncodeBit encodes the least-significant bit of b with probability 1/2.
 func (e *rangeEncoder) DirectEncodeBit(b uint32) error {
 	e.nrange >>= 1
-	e.low += uint64(e.nrange) & (0 - (uint64(b) & 1))
+	e.low += uint64(e.nrange) & (0 - uint64(b)&1)
 
 	// normalize
 	const top = 1 << 24
@@ -101,7 +101,7 @@ func (e *rangeEncoder) Close() error {
 // shiftLow shifts the low value for 8 bit. The shifted byte is written into
 // the byte writer. The cache value is used to handle overflows.
 func (e *rangeEncoder) shiftLow() error {
-	if uint32(e.low) < 0xff000000 || (e.low>>32) != 0 {
+	if uint32(e.low) < 0xff000000 || e.low>>32 != 0 {
 		tmp := e.cache
 		for {
 			err := e.writeByte(tmp + byte(e.low>>32))
@@ -194,7 +194,7 @@ func (d *rangeDecoder) possiblyAtEnd() bool {
 func (d *rangeDecoder) DirectDecodeBit() (b uint32, err error) {
 	d.nrange >>= 1
 	d.code -= d.nrange
-	t := 0 - (d.code >> 31)
+	t := 0 - d.code>>31
 	d.code += d.nrange & t
 	b = (t + 1) & 1
 
@@ -243,6 +243,6 @@ func (d *rangeDecoder) updateCode() error {
 	if err != nil {
 		return err
 	}
-	d.code = (d.code << 8) | uint32(b)
+	d.code = d.code<<8 | uint32(b)
 	return nil
 }


### PR DESCRIPTION
This PR changes `type lit` to be `byte` instead of a struct containing a byte. This improves performance slightly at least on my workload.

```
before:
BenchmarkBlocksFromMemory-4           27          60508126 ns/op

after: 
BenchmarkBlocksFromMemory-4           28          54614319 ns/op
```

Before:
![Screenshot 2020-04-18 at 4 21 53 PM](https://user-images.githubusercontent.com/3770794/79673693-cd6d7d80-8190-11ea-97a5-99fc409b59de.png)
notice how much time `decodeLiteral` spends calling `runtime.convT2Inoptr`

After: 
![Screenshot 2020-04-18 at 4 21 20 PM](https://user-images.githubusercontent.com/3770794/79673692-ccd4e700-8190-11ea-89a0-0c76cead11dd.png)
that call is eliminated