### PR TITLE
Export processFile function

### DIFF
--- a/cmd/gxz/file.go
+++ b/cmd/gxz/file.go
@@ -478,9 +478,9 @@ func printErr(err error) {
 	}
 }
 
-// processFile process the file with the given path applying the
-// provided options.
-func processFile(path string, opts *options) (err error) {
+// ProcessFile processes the file with the given path applying 
+// the provided options.
+func ProcessFile(path string, opts *options) (err error) {
 	r, err := newReader(path, opts)
 	if err != nil {
 		printErr(err)

--- a/cmd/gxz/main.go
+++ b/cmd/gxz/main.go
@@ -230,7 +230,7 @@ Use -f to force compression. For help type gxz -h.`)
 
 	exit := 0
 	for _, arg := range args {
-		if err := processFile(arg, &opts); err != nil {
+		if err := ProcessFile(arg, &opts); err != nil {
 			exit = 1
 		}
 	}


### PR DESCRIPTION
This PR exports the `processFile` method, to allow it to be called programmatically from other Golang programs. 

This function has useful functionality to run `xz` on file objects. As such, it'd be helpful to export it to allow it to be called from outside the scope of this program. 