### PR TITLE
Remove the check on dictionary capacity

### DIFF
--- a/lzma/reader.go
+++ b/lzma/reader.go
@@ -69,9 +69,6 @@ func (c ReaderConfig) NewReader(lzma io.Reader) (r *Reader, err error) {
 	if err = r.h.unmarshalBinary(data); err != nil {
 		return nil, err
 	}
-	if r.h.dictCap < MinDictCap {
-		return nil, errors.New("lzma: dictionary capacity too small")
-	}
 	dictCap := r.h.dictCap
 	if c.DictCap > dictCap {
 		dictCap = c.DictCap


### PR DESCRIPTION
I'm using your xz package in my 7-zip reader package to decompress LZMA and LZMA2 streams. I've had some reports of some archives being unreadable with a `lzma: dictionary capacity too small` error.

I thought I could override the default `ReaderConfig` and set a bigger dictionary capacity however it seems the check that triggers this error fires before the capacity is overridden by the `ReaderConfig.DictCap` value. The default `DictCap` value is much bigger than `MinDictCap` anyway, (8 MB vs 4 KB IIRC).

Removing this check allows the `ReaderConfig.DictCap` value to override whatever was in the stream header and it's guaranteed to be at least `MinDictCap` thanks to `ReaderConfig.Verify()`.

The unreadable LZMA streams were then readable.
