### PR TITLE
feat: inline DecodeBit function for improved performance

### DIFF
--- a/lzma/directcodec.go
+++ b/lzma/directcodec.go
@@ -27,12 +27,5 @@ func (dc directCodec) Encode(e *rangeEncoder, v uint32) error {
 // Decode uses the range decoder to decode a value with the given number of
 // given bits. The most-significant bit is decoded first.
 func (dc directCodec) Decode(d *rangeDecoder) (v uint32, err error) {
-	for i := int(dc) - 1; i >= 0; i-- {
-		x, err := d.DirectDecodeBit()
-		if err != nil {
-			return 0, err
-		}
-		v = (v << 1) | x
-	}
-	return v, nil
+	return d.directDecodeBits(int(dc))
 }

--- a/lzma/literalcodec.go
+++ b/lzma/literalcodec.go
@@ -81,25 +81,12 @@ func (c *literalCodec) Decode(d *rangeDecoder,
 ) (s byte, err error) {
 	k := litState * 0x300
 	probs := c.probs[k : k+0x300]
-	symbol := uint32(1)
 	if state >= 7 {
-		m := uint32(match)
-		for {
-			matchBit := (m >> 7) & 1
-			m <<= 1
-			i := ((1 + matchBit) << 8) | symbol
-			bit, err := d.DecodeBit(&probs[i])
-			if err != nil {
-				return 0, err
-			}
-			symbol = (symbol << 1) | bit
-			if matchBit != bit {
-				break
-			}
-			if symbol >= 0x100 {
-				break
-			}
+		x, err := d.treeDecodeMatchedByte(probs, uint32(match))
+		if err != nil {
+			return 0, err
 		}
+		return byte(x), nil
 	} else {
 		x, err := d.treeDecodeBits(probs, 8)
 		if err != nil {
@@ -107,15 +94,6 @@ func (c *literalCodec) Decode(d *rangeDecoder,
 		}
 		return byte(x), nil
 	}
-	for symbol < 0x100 {
-		bit, err := d.DecodeBit(&probs[symbol])
-		if err != nil {
-			return 0, err
-		}
-		symbol = (symbol << 1) | bit
-	}
-	s = byte(symbol - 0x100)
-	return s, nil
 }
 
 // minLC and maxLC define the range for LC values.

--- a/lzma/literalcodec.go
+++ b/lzma/literalcodec.go
@@ -100,6 +100,12 @@ func (c *literalCodec) Decode(d *rangeDecoder,
 				break
 			}
 		}
+	} else {
+		x, err := d.treeDecodeBits(probs, 8)
+		if err != nil {
+			return 0, err
+		}
+		return byte(x), nil
 	}
 	for symbol < 0x100 {
 		bit, err := d.DecodeBit(&probs[symbol])

--- a/lzma/rangecodec.go
+++ b/lzma/rangecodec.go
@@ -185,7 +185,7 @@ func (d *rangeDecoder) DirectDecodeBit() (b uint32, err error) {
 	return b, d.updateCode()
 }
 
-// decodeBit decodes a single bit. The bit will be returned at the
+// DecodeBit decodes a single bit. The bit will be returned at the
 // least-significant position. All other bits will be zero. The probability
 // value will be updated.
 func (d *rangeDecoder) DecodeBit(p *prob) (b uint32, err error) {
@@ -209,6 +209,94 @@ func (d *rangeDecoder) DecodeBit(p *prob) (b uint32, err error) {
 	d.nrange <<= 8
 	// d.code < d.nrange will be maintained
 	return b, d.updateCode()
+}
+
+func (d *rangeDecoder) treeDecodeBits(ps []prob, n int) (uint32, error) {
+	nrange, code := d.nrange, d.code
+	symbol := uint32(1)
+
+	for i := 0; i < n; i++ {
+		p := &ps[symbol]
+		bound := p.bound(nrange)
+		if code < bound {
+			p.inc()
+			nrange = bound
+			symbol = symbol<<1 | 0
+		} else {
+			p.dec()
+			nrange -= bound
+			code -= bound
+			symbol = symbol<<1 | 1
+		}
+		if nrange < 1<<24 {
+			b, err := d.br.ReadByte()
+			if err != nil {
+				d.nrange, d.code = nrange, code
+				return 0, err
+			}
+			nrange <<= 8
+			code = code<<8 | uint32(b)
+		}
+	}
+	d.nrange, d.code = nrange, code
+	return symbol - uint32(1<<uint(n)), nil
+}
+
+func (d *rangeDecoder) reverseTreeDecodeBits(ps []prob, n int) (uint32, error) {
+	nrange, code := d.nrange, d.code
+	symbol := uint32(1)
+	x := uint32(0)
+
+	for i := 0; i < n; i++ {
+		p := &ps[symbol]
+		bound := p.bound(nrange)
+		if code < bound {
+			p.inc()
+			nrange = bound
+			symbol = symbol<<1 | 0
+		} else {
+			p.dec()
+			nrange -= bound
+			code -= bound
+			symbol = symbol<<1 | 1
+			x |= 1 << uint(i)
+		}
+		if nrange < 1<<24 {
+			b, err := d.br.ReadByte()
+			if err != nil {
+				d.nrange, d.code = nrange, code
+				return 0, err
+			}
+			nrange <<= 8
+			code = code<<8 | uint32(b)
+		}
+	}
+	d.nrange, d.code = nrange, code
+	return x, nil
+}
+
+func (d *rangeDecoder) directDecodeBits(n int) (uint32, error) {
+	nrange, code := d.nrange, d.code
+	x := uint32(0)
+
+	for i := 0; i < n; i++ {
+		nrange >>= 1
+		code -= nrange
+		t := 0 - (code >> 31)
+		code += nrange & t
+		x = x<<1 | (t+1)&1
+		if nrange < 1<<24 {
+			b, err := d.br.ReadByte()
+			if err != nil {
+				d.nrange, d.code = nrange, code
+				return 0, err
+			}
+			nrange <<= 8
+			code = code<<8 | uint32(b)
+		}
+	}
+	d.nrange, d.code = nrange, code
+	return x, nil
 }
 
 // updateCode reads a new byte into the code.

--- a/lzma/treecodecs.go
+++ b/lzma/treecodecs.go
@@ -34,18 +34,10 @@ func (tc *treeCodec) Encode(e *rangeEncoder, v uint32) (err error) {
 	return nil
 }
 
-// Decodes uses the range decoder to decode a fixed-bit-size value. Errors may
+// Decode uses the range decoder to decode a fixed-bit-size value. Errors may
 // be caused by the range decoder.
 func (tc *treeCodec) Decode(d *rangeDecoder) (v uint32, err error) {
-	m := uint32(1)
-	for j := 0; j < int(tc.bits); j++ {
-		b, err := d.DecodeBit(&tc.probs[m])
-		if err != nil {
-			return 0, err
-		}
-		m = (m << 1) | b
-	}
-	return m - (1 << uint(tc.bits)), nil
+	return d.treeDecodeBits(tc.probs, int(tc.bits))
 }
 
 // treeReverseCodec is another tree codec, where the least-significant bit is
@@ -80,19 +72,10 @@ func (tc *treeReverseCodec) Encode(v uint32, e *rangeEncoder) (err error) {
 	return nil
 }
 
-// Decodes uses the range decoder to decode a fixed-bit-size value. Errors
+// Decode uses the range decoder to decode a fixed-bit-size value. Errors
 // returned by the range decoder will be returned.
 func (tc *treeReverseCodec) Decode(d *rangeDecoder) (v uint32, err error) {
-	m := uint32(1)
-	for j := uint(0); j < uint(tc.bits); j++ {
-		b, err := d.DecodeBit(&tc.probs[m])
-		if err != nil {
-			return 0, err
-		}
-		m = (m << 1) | b
-		v |= b << j
-	}
-	return v, nil
+	return d.reverseTreeDecodeBits(tc.probs, int(tc.bits))
 }
 
 // probTree stores enough probability values to be used by the treeEncode and


### PR DESCRIPTION
## Description:

With immense respect for the work done so far, I am writing this pull request to propose an optimization that would enhance the performance of the `github.com/bodgit/sevenzip` project, which relies on the `lzma` module from `github.com/ulikunitz/xz`.

Currently, I am working on the decompression of large-scale 7z archives (using lzma2) in the GB range. As part of this effort, I have noticed that the repetitive calls to the DecodeBit function within the rangeDecoder module lead to frequent memory writes and potential performance bottlenecks.

To address this issue, I propose inlining the DecodeBit function, which would reduce the overhead of function calls and make efficient use of registers for intermediate states. By doing so, we can significantly improve the decompression performance of large-scale 7z archives.

The key advantages of this optimization include:

* Efficient usage of registers to store intermediate states, resulting in fewer memory accesses.
* Reducing function call overhead by eliminating the need to save and restore the caller's context.

During my local testing, I observed a notable performance improvement of approximately 19% in scenarios involving repetitive calls to DecodeBit. This suggests the potential benefits it can bring to the `github.com/bodgit/sevenzip` project, particularly when decompressing GB-sized 7z archives.

before:
```
goos: linux
goarch: amd64
pkg: github.com/bodgit/sevenzip
cpu: Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz
BenchmarkLargeLZMA2-8   	       1	400362537495 ns/op
```

after:
```
goos: linux
goarch: amd64
pkg: github.com/bodgit/sevenzip
cpu: Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz
BenchmarkLargeLZMA2-8   	       1	323613023997 ns/op
```

I kindly request your review and feedback on this pull request. Thank you.