### PR TITLE
feat: added limitedByteReader to avoid breader

### DIFF
--- a/lzma/bytereader.go
+++ b/lzma/bytereader.go
@@ -1,0 +1,28 @@
+package lzma
+
+import (
+	"io"
+)
+
+func limitByteReader(br io.ByteReader, n int64) *limitedByteReader {
+	return &limitedByteReader{
+		BR: br,
+		N:  n,
+	}
+}
+
+type limitedByteReader struct {
+	BR io.ByteReader
+	N  int64
+}
+
+func (r *limitedByteReader) ReadByte() (b byte, err error) {
+	if r.N <= 0 {
+		return 0, io.EOF
+	}
+	b, err = r.BR.ReadByte()
+	if err == nil {
+		r.N -= 1
+	}
+	return
+}

--- a/lzma/reader2.go
+++ b/lzma/reader2.go
@@ -107,7 +107,7 @@ func (r *Reader2) startChunk() error {
 		r.chunkReader = r.ur
 		return nil
 	}
-	br := ByteReader(io.LimitReader(r.r, int64(header.compressed)+1))
+	br := limitByteReader(ByteReader(r.r), int64(header.compressed)+1)
 	if r.decoder == nil {
 		state := newState(header.props)
 		r.decoder, err = newDecoder(br, state, r.dict, size)


### PR DESCRIPTION
The ByteReader function in some cases creates a breader that reads one byte at a time, resulting in inefficient performance. However, if the passed Reader implements io.ByteReader, it is more efficient to use it instead.

In the case of LZMA2, it is wrapped with io.LimitReader, which inadvertently triggers the usage of breader.
To avoid this, I have added an io.ByteReader with the functionality of io.LimitedReader. This change has shown approximately a 10% performance improvement.

I kindly request your review and feedback on this pull request. Thank you.