### PR TITLE
lzma: make operation a concrete type

### DIFF
--- a/lzma/hashtable.go
+++ b/lzma/hashtable.go
@@ -261,7 +261,7 @@ func (t *hashTable) NextOp(rep [4]uint32) operation {
 	}
 
 	// check distances
-	var m match
+	var m operation
 	dictLen := t.dict.DictLen()
 	for _, dist := range dists {
 		if dist > dictLen {
@@ -274,11 +274,12 @@ func (t *hashTable) NextOp(rep [4]uint32) operation {
 		// the given distance, we test the first byte that would
 		// make the match longer. If it doesn't match the byte
 		// to match, we don't to care any longer.
-		i := t.dict.buf.rear - dist + m.n
+		mLength := m.length()
+		i := t.dict.buf.rear - dist + mLength
 		if i < 0 {
 			i += len(t.dict.buf.data)
 		}
-		if t.dict.buf.data[i] != data[m.n] {
+		if t.dict.buf.data[i] != data[mLength] {
 			// We can't get a longer match. Jump to the next
 			// distance.
 			continue
@@ -293,8 +294,8 @@ func (t *hashTable) NextOp(rep [4]uint32) operation {
 				continue
 			}
 		}
-		if n > m.n {
-			m = match{int64(dist), n}
+		if n > mLength {
+			m = makeMatchOp(int64(dist), n)
 			if n == len(data) {
 				// No better match will be found.
 				break
@@ -302,8 +303,8 @@ func (t *hashTable) NextOp(rep [4]uint32) operation {
 		}
 	}
 
-	if m.n == 0 {
-		return lit{data[0]}
+	if m == 0 {
+		return makeLitOp(data[0])
 	}
 	return m
 }

--- a/lzma/operation.go
+++ b/lzma/operation.go
@@ -10,46 +10,50 @@ import (
 )
 
 // operation represents an operation on the dictionary during encoding or
-// decoding.
-type operation interface {
-	Len() int
-}
+// decoding. They are either matches or literals (or are invalid), packed into
+// 64 bits (16 4-bit nibbles) as:
+//
+//	most significant bits                      least significant bits
+//	+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+//	|TYP|LITERAL|     LENGTH    |              DISTANCE             |
+//	+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+//	   60  56  52  48  44  40  36  32  28  24  20  16  12   8   4   0
+//
+// TYP (4 bits) is 0x8 for literal operations and 0x0 for match operations.
+//
+// LITERAL (8 bits) is the literal byte, unused (0) for match operations.
+//
+// LENGTH (16 bits, since maxMatchLen = 273) is the match length or 1 for
+// literal operations.
+//
+// DISTANCE (36 bits, since maxDistance = 1 << 32) is the match distance,
+// unused (0) for literal operations.
+//
+// The zero value is an invalid operation. Valid operations have positive
+// length().
+type operation uint64
 
-// rep represents a repetition at the given distance and the given length
-type match struct {
-	// supports all possible distance values, including the eos marker
-	distance int64
-	// length
-	n int
-}
+func (o operation) distance() int64 { return int64(o & 0xFFFFFFFFF) }
+func (o operation) length() int     { return int(uint16(o >> 36)) }
+func (o operation) literal() byte   { return byte(o >> 52) }
+func (o operation) isLiteral() bool { return int64(o) < 0 }
 
-// Len returns the number of bytes matched.
-func (m match) Len() int {
-	return m.n
-}
-
-// String returns a string representation for the repetition.
-func (m match) String() string {
-	return fmt.Sprintf("M{%d,%d}", m.distance, m.n)
-}
-
-// lit represents a single byte literal.
-type lit struct {
-	b byte
-}
-
-// Len returns 1 for the single byte literal.
-func (l lit) Len() int {
-	return 1
-}
-
-// String returns a string representation for the literal.
-func (l lit) String() string {
-	var c byte
-	if unicode.IsPrint(rune(l.b)) {
-		c = l.b
-	} else {
-		c = '.'
+func (o operation) String() string {
+	if o.isLiteral() {
+		c := o.literal()
+		if !unicode.IsPrint(rune(c)) {
+			c = '.'
+		}
+		return fmt.Sprintf("L{%c/%02x}", c, c)
 	}
-	return fmt.Sprintf("L{%c/%02x}", c, l.b)
+
+	return fmt.Sprintf("M{%d,%d}", o.distance(), o.length())
+}
+
+func makeMatchOp(distance int64, length int) operation {
+	return operation(distance&0xFFFFFFFFF) | (operation(length&0xFFFF) << 36)
+}
+
+func makeLitOp(b byte) operation {
+	return 0x8000001000000000 | (operation(b) << 52)
 }


### PR DESCRIPTION
Prior to this commit, operation was an interface type, which meant that every call to methods like binTree.NextOp or hashTable.NextOp, which could return either a match op or a literal op, would dynamically allocate memory (and eventually require garbage collection).

After this commit, the "package xz" benchmarks show a modest speed gain and a dramatic fall in the number of allocations.

name      old speed      new speed      delta
Reader-8  28.9MB/s ± 0%  32.0MB/s ± 0%  +11.01%  (p=0.008 n=5+5)
Writer-8  6.50MB/s ± 0%  6.95MB/s ± 1%   +6.99%  (p=0.008 n=5+5)

name      old alloc/op   new alloc/op   delta
Reader-8    37.3MB ± 0%    15.5MB ± 0%  -58.39%  (p=0.008 n=5+5)
Writer-8    80.2MB ± 0%    60.8MB ± 0%  -24.19%  (p=0.000 n=5+4)

name      old allocs/op  new allocs/op  delta
Reader-8     1.21M ± 0%     0.00M ± 0%  -99.96%  (p=0.008 n=5+5)
Writer-8     1.22M ± 0%     0.00M ± 0%  -99.62%  (p=0.000 n=5+4)