### PR TITLE
Run tests in CI

### DIFF
--- a/.github/workflows/go-test-platforms.yml
+++ b/.github/workflows/go-test-platforms.yml
@@ -26,6 +26,7 @@ jobs:
       - run: GOARCH=386 go build
       - run: GOARCH=386 go test -c ./...
       - run: GOARCH=386 go test ./...
+
   go-test-windows:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/go-test-platforms.yml
+++ b/.github/workflows/go-test-platforms.yml
@@ -31,8 +31,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/go-test-platforms.yml
+++ b/.github/workflows/go-test-platforms.yml
@@ -1,0 +1,42 @@
+name: Test on Linux/amd64, Linux/x86, and Windows/amd64
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  go-test-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # Split testing into parts to see which part (if any) is slow. Dependency
+      # downloads can be for instance.
+      - run: go build -race
+      - run: go test -race -c ./...
+      - run: go test -race ./...
+
+      # The -race detector is not available on 386, so let's not use it here:
+      # https://go.dev/doc/articles/race_detector
+      - run: GOARCH=386 go build
+      - run: GOARCH=386 go test -c ./...
+      - run: GOARCH=386 go test ./...
+  go-test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # Split testing into parts to see which part (if any) is slow. Dependency
+      # downloads can be for instance.
+      - run: go build -race
+      - run: go test -race -c ./...
+      - run: go test -race ./...

--- a/TODO.md
+++ b/TODO.md
@@ -74,7 +74,7 @@
 * Update README.md
 * xb copyright . in xz directory to ensure all new files have Copyright header
 * `VERSION=<version> go generate github.com/ulikunitz/xz/...` to update version files
-* Execute test for Linux/amd64, Linux/x86 and Windows/amd64.
+* Execute [test for Linux/amd64, Linux/x86 and Windows/amd64](.github/workflows/go-test-platforms.yml).
 * Update TODO.md - write short log entry
 * `git checkout master && git merge dev`
 * `git tag -a <version>`


### PR DESCRIPTION
Runs the tests listed in `TODO.md`: https://github.com/ulikunitz/xz/blob/7eee8a8a405163554a9accec7b9402ee21400769/TODO.md?plain=1#L77

Uses Go's race detector on supported platforms.

The point is to prevent future instances of #65, and to simplify the release procedure.
