### PR TITLE
Extend gxz build to illumos

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/ulikunitz/xz
 
 go 1.20
+
+require golang.org/x/sys v0.29.0

--- a/internal/term/ioctl_bsd.go
+++ b/internal/term/ioctl_bsd.go
@@ -7,6 +7,6 @@
 
 package term
 
-import "syscall"
+import "golang.org/x/sys/unix"
 
-const ioctlGetTermios = syscall.TIOCGETA
+const ioctlGetTermios = unix.TIOCGETA

--- a/internal/term/ioctl_illumos.go
+++ b/internal/term/ioctl_illumos.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build illumos
+// +build illumos
+
 package term
 
 import "golang.org/x/sys/unix"

--- a/internal/term/isterminal.go
+++ b/internal/term/isterminal.go
@@ -2,21 +2,16 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build darwin || dragonfly || freebsd || (linux && !appengine) || netbsd || openbsd
-// +build darwin dragonfly freebsd linux,!appengine netbsd openbsd
+//go:build darwin || dragonfly || freebsd || (linux && !appengine) || netbsd || openbsd || illumos
+// +build darwin dragonfly freebsd linux,!appengine netbsd openbsd illumos
 
 // Package term provides the IsTerminal function.
 package term
 
-import (
-	"syscall"
-	"unsafe"
-)
+import "golang.org/x/sys/unix"
 
 // IsTerminal returns true if the given file descriptor is a terminal.
 func IsTerminal(fd uintptr) bool {
-	var termios syscall.Termios
-	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd,
-		ioctlGetTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
-	return err == 0
+	_, err := unix.IoctlGetTermios(int(fd), ioctlGetTermios)
+	return err == nil
 }


### PR DESCRIPTION
An attempt to add illumos platform, in order to fix https://github.com/ulikunitz/xz/issues/75 (it doesn't block the Forgejo build itself, but I'd like to see if the problem is fixable)

It seems that "syscall" package doesn't implement Solaris/illumos part (see https://github.com/golang/go/issues/24357), so I followed the recommendation to use "sys/unix" instead.

@ulikunitz could you please advise, if this is the right approach and what needs to be changed else to accept the patch? I'm not very versed with Golang, so I may miss something obvious.