### PR TITLE
lzma: fix roundtrip for a known uncompressed size of zero (#71)

### DIFF
--- a/lzma/decoder.go
+++ b/lzma/decoder.go
@@ -197,6 +197,15 @@ func (d *decoder) decompress() error {
 		return io.EOF
 	}
 	for d.Dict.Available() >= maxMatchLen {
+		if d.size >= 0 && d.Decompressed() >= d.size {
+			// The uncompressed size announced in the header has
+			// already been reached before reading an operation. This
+			// happens for a known size of zero: the stream carries no
+			// operation and no EOS marker, so finish here instead of
+			// reading past the end of the stream.
+			d.eos = true
+			return io.EOF
+		}
 		op, err := d.readOp()
 		switch err {
 		case nil:

--- a/lzma/header.go
+++ b/lzma/header.go
@@ -88,7 +88,7 @@ func (h *Header) marshalBinary() (data []byte, err error) {
 
 	// uncompressed size
 	var s uint64
-	if h.Size > 0 {
+	if h.Size >= 0 {
 		s = uint64(h.Size)
 	} else {
 		s = noHeaderSize

--- a/lzma/writer_test.go
+++ b/lzma/writer_test.go
@@ -247,3 +247,78 @@ func BenchmarkWriter(b *testing.B) {
 		}
 	}
 }
+
+// TestWriterSizeZero verifies that a writer configured with an explicit,
+// known size of zero produces a stream its own reader can decode. Size 0 is a
+// valid known size (the library's invariant is that a NEGATIVE size means
+// "unknown", see Header.Size in header.go), so the header must advertise the
+// known size 0 rather than the "size unknown" sentinel. Regression test for
+// issue #71: before the header.go fix the header encoded size 0 as "unknown",
+// which tells the reader to expect an EOS marker, but the writer emits no EOS
+// marker (EOSMarker is false when the size is in the header), so NewReader
+// failed with io.ErrUnexpectedEOF on the writer's own output.
+func TestWriterSizeZero(t *testing.T) {
+	buf := new(bytes.Buffer)
+	w, err := WriterConfig{
+		Properties:   &Properties{LC: 3, LP: 0, PB: 2},
+		SizeInHeader: true,
+		Size:         0,
+	}.NewWriter(buf)
+	if err != nil {
+		t.Fatalf("NewWriter error %s", err)
+	}
+	if err = w.Close(); err != nil {
+		t.Fatalf("w.Close error %s", err)
+	}
+	r, err := NewReader(buf)
+	if err != nil {
+		t.Fatalf("NewReader error %s", err)
+	}
+	out, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll error %s; want nil (writer emitted a stream its own reader rejects)", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("decoded %d bytes; want 0", len(out))
+	}
+}
+
+// TestWriterDefaultRoundtrip guards the default streaming writer and documents
+// why the fix for issue #71 deliberately excludes the reporter's proposed
+// WriterConfig.fill change. The reporter proposed changing fill from
+// "if c.Size > 0" to "if c.Size >= 0", but that regresses this path:
+// NewWriter(w) uses a zero-value config, so
+// Size == 0. With the proposed fill change, fill would set SizeInHeader = true
+// for the zero-value config, giving the writer a known size of 0; every Write
+// would then be capped to zero bytes (see Writer.Write) and return ErrNoSpace,
+// so "hello world" below would never reach the stream. This test passes before
+// and after the header.go fix, and fails if the fill change is applied.
+func TestWriterDefaultRoundtrip(t *testing.T) {
+	const msg = "hello world"
+	buf := new(bytes.Buffer)
+	w, err := NewWriter(buf)
+	if err != nil {
+		t.Fatalf("NewWriter error %s", err)
+	}
+	n, err := w.Write([]byte(msg))
+	if err != nil {
+		t.Fatalf("w.Write error %s", err)
+	}
+	if n != len(msg) {
+		t.Fatalf("w.Write wrote %d bytes; want %d", n, len(msg))
+	}
+	if err = w.Close(); err != nil {
+		t.Fatalf("w.Close error %s", err)
+	}
+	r, err := NewReader(buf)
+	if err != nil {
+		t.Fatalf("NewReader error %s", err)
+	}
+	out, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll error %s", err)
+	}
+	if string(out) != msg {
+		t.Fatalf("decoded %q; want %q", out, msg)
+	}
+}


### PR DESCRIPTION
## Repro

A classic-format writer created with the size in the header and `Size: 0`, writing no payload, produces a stream that the package's own reader cannot decode:

```go
var buf bytes.Buffer
p := lzma.Properties{LC: 3, LP: 0, PB: 2}
w, _ := lzma.WriterConfig{Properties: &p, SizeInHeader: true, Size: 0}.NewWriter(&buf)
w.Close()

r, _ := lzma.NewReader(bytes.NewReader(buf.Bytes()))
got, err := io.ReadAll(r)
// before: got len=0, err=unexpected EOF
// after:  got len=0, err=<nil>
```

The writer emits a stream its own reader rejects -- a roundtrip self-inconsistency.

## Root cause (two bugs)

**1. Encode side -- `lzma/header.go`, `marshalBinary`.** The size field was guarded by `if h.Size > 0`, so a valid *known* size of `0` was encoded as `noHeaderSize` (0xFFFFFFFFFFFFFFFF), i.e. "size unknown". The library's documented invariant is that a **negative** `Size` means unknown (see the `Header.Size` doc comment and `unmarshalBinary`, which sets `-1` only for the sentinel), so `0` is a valid known size. Advertising "unknown" tells the reader to expect an EOS marker, but the writer correctly emits no EOS marker when the size is in the header -- so the stream is contradictory. Fix: `> 0` -> `>= 0`.

**2. Decode side -- `lzma/decoder.go`, `decompress`.** Even with a correct header (`size == 0`), the decode loop called `readOp()` before the size-reached check, so for a known size of zero it tried to decode an operation from an empty payload and hit `io.ErrUnexpectedEOF`. Fix: stop cleanly when the announced size has already been reached before reading an operation (produces 0 bytes, no error). This only affects the size-already-satisfied-at-entry case (size 0); streams with size > 0 are unchanged.

Both changes are required -- either one alone still fails with `unexpected EOF` (covered by the added test).

## Tests

- `TestWriterSizeZero` -- the size-0 writer->reader roundtrip; fails on `master` with `unexpected EOF`, passes with this change.
- `TestWriterDefaultRoundtrip` -- guards the default streaming writer (`NewWriter` + "hello world" roundtrip).

## Credit and scope

Thanks to @lczyk for reporting #71 and for correctly identifying the `header.go` `> 0` mis-encoding. Two notes on scope:

- Their proposed fix was **incomplete**: fixing only `header.go` does not make the repro pass, because the decoder also cannot decode a known size of `0`. This PR adds the required decoder fix as well.
- Their second suggestion -- changing `WriterConfig.fill` from `if c.Size > 0` to `if c.Size >= 0` -- is **deliberately excluded** because it regresses the default streaming writer: `NewWriter(w)` uses a zero-value config (`Size == 0`), so that change would auto-set `SizeInHeader`, giving the writer a known size of 0 and capping every `Write` to zero bytes (`ErrNoSpace`). `TestWriterDefaultRoundtrip` documents and guards this.

---
This change was prepared with AI assistance and reviewed by me before submission.
